### PR TITLE
Prevent logout when backend returns error

### DIFF
--- a/app/frontend/src/app/api-auth/refresh.interceptor.ts
+++ b/app/frontend/src/app/api-auth/refresh.interceptor.ts
@@ -17,6 +17,11 @@ export class RefreshInterceptor implements HttpInterceptor {
     return next.handle(request)
       .pipe(
         catchError((error: HttpErrorResponse) => {
+          if (error.status != 401) {
+            // ignore if it is not unauthorized error
+            return throwError(error);
+          }
+
           if (this.isAuthRequest(request)) {
             if (this.isRefreshRequest(request)) {
               this.loginService.logout();


### PR DESCRIPTION
Previously, the interceptor assumes all errors are unauthorized errors. Added a status code check for unauthorized errors, so it should work as long as backend does not inappropriately use the status code.