### PR TITLE
Merge two template pages and hide send email tab

### DIFF
--- a/app/backend/confirmationemails/urls.py
+++ b/app/backend/confirmationemails/urls.py
@@ -1,7 +1,10 @@
+from django.urls import path
 from django.conf.urls import url
 from confirmationemails import views
 
 urlpatterns = [
+    path('confirmation_templates', views.confirmation_template_list),
+    path('confirmation_template/<int:pk>', views.confirmation_template_detail),
     url('update_confirmation', views.create_or_update_confirmation_template),
     url('get_confirmation', views.get_confirmation_template),
     url('resend_confirmation', views.resend_confirmation)

--- a/app/backend/confirmationemails/views.py
+++ b/app/backend/confirmationemails/views.py
@@ -11,6 +11,21 @@ from confirmationemails.templates import send_confirmation_email
 from confirmationemails.models import ConfirmationEmail
 from confirmationemails.serializers import ConfirmationEmailSerializer
 
+import sys
+sys.path.append('../')
+from meridien import views_template
+
+@api_view(['GET', 'POST'])
+@permission_classes([IsAuthenticated])
+@csrf_exempt
+def confirmation_template_list(request):
+    return views_template.obj_list(request, ConfirmationEmail, ConfirmationEmailSerializer)
+
+@api_view(['GET', 'PUT'])
+@permission_classes([IsAuthenticated])
+@csrf_exempt
+def confirmation_template_detail(request, pk):
+    return views_template.obj_detail(request, pk, ConfirmationEmail, ConfirmationEmailSerializer)
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])

--- a/app/frontend/src/app/app.module.ts
+++ b/app/frontend/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { FullCalendarModule } from '@fullcalendar/angular';
 import dayGridPlugin from '@fullcalendar/daygrid';
 
+import { ConfirmationDetailDialog } from './template-list/confirmation-detail.dialog'
 import { TemplateDetailDialog } from './template-list/template-detail.dialog';
 import { RefreshInterceptor } from './api-auth/refresh.interceptor';
 import { JwtInterceptor } from './api-auth/jwt.interceptor';
@@ -71,6 +72,7 @@ FullCalendarModule.registerPlugins([ // register FullCalendar plugins
     LoginFormComponent,
     LogoutComponent,
     TemplateListComponent,
+    ConfirmationDetailDialog,
     TemplateDetailDialog,
     MailSenderComponent,
     BookingConfirmComponent,

--- a/app/frontend/src/app/model-service/confirmationtemplates/confirmationtemplates.service.ts
+++ b/app/frontend/src/app/model-service/confirmationtemplates/confirmationtemplates.service.ts
@@ -1,7 +1,9 @@
 import { environment } from './../../../environments/environment';
+import { ConfirmationTemplate } from './confirmationtemplates';
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -10,7 +12,26 @@ export class ConfirmationTemplatesService {
   private postUrl = environment.apiUrl + 'update_confirmation';
   private resendUrl = environment.apiUrl + 'resend_confirmation';
 
+  private baseUrlTemplates = environment.apiUrl + 'confirmation_templates';
+  private baseUrlTemplate = environment.apiUrl + 'confirmation_template';
+
   constructor(private http: HttpClient) { }
+
+  getConfirmationTemplateList(): Observable<any> {
+    return this.http.get(`${this.baseUrlTemplates}`);
+  }
+
+  getConfirmationTemplateById(id: number): Observable<any> {
+    return this.http.get(`${this.baseUrlTemplate}/${id}`);
+  }
+
+  updateConfirmationTemplate(id: number, value: any): Observable<Object> {
+    return this.http.put(`${this.baseUrlTemplate}/${id}`, value);
+  }
+
+  createConfirmationTemplate(template: ConfirmationTemplate): Observable<Object> {
+    return this.http.post(`${this.baseUrlTemplates}`, template);
+  }
 
   getConfirmationTemplate(): Observable<any> {
     return this.http.get(`${this.getUrl}`);

--- a/app/frontend/src/app/template-list/confirmation-detail.dialog.html
+++ b/app/frontend/src/app/template-list/confirmation-detail.dialog.html
@@ -1,0 +1,76 @@
+<style>
+    .column-left {
+        float: left;
+        width: 30%;
+    }
+
+    .column-right {
+        float: right;
+        width: 70%;
+    }
+
+    .row:after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+
+    ul {
+        list-style-type: none;
+        margin-top: 4px;
+    }
+</style>
+
+<h1 mat-dialog-title>{{'Edit Confirmation Mail Template'}}</h1>
+<div class="row">
+    <div class="column-left">
+        <p style="margin-top: 100%; color: #cccccc;">Edit your confirmation template here :D</p>
+    </div>
+    <div class="column-right">
+        <form class="container" style="padding-top:15px; padding-left: 30px; padding-right: 30px; padding-bottom: 20px;" [formGroup]="confirmationMailForm">
+            <mat-form-field appearance="fill" style="width: 100%">
+                <mat-label for="link_string">Link Placeholder</mat-label>
+                <input matInput formControlName="link_string">
+            </mat-form-field>
+            <br>
+            <mat-form-field appearance="fill" style="width: 100%">
+                <mat-label for="subject">Subject</mat-label>
+                <input matInput formControlName="subject">
+            </mat-form-field>
+            <br>
+            <editor 
+                formControlName="template"
+                [apiKey]="apiKey"
+                [init]="{
+                height: 300,
+                menubar: false,
+                plugins: [
+                    'advlist autolink lists link image charmap print preview anchor',
+                    'searchreplace visualblocks code fullscreen',
+                    'insertdatetime media table paste code help wordcount',
+                    'table'
+                ],
+                toolbar:
+                    'undo redo | formatselect | bold italic underline backcolor | \
+                    alignleft aligncenter alignright alignjustify | \
+                    bullist numlist outdent indent | removeformat | help \
+                    table tabledelete | tableprops tablerowprops tablecellprops | \
+                    tableinsertrowbefore tableinsertrowafter tabledeleterow | \ 
+                    tableinsertcolbefore tableinsertcolafter tabledeletecol | tablemergecells'
+                }"
+            ></editor>
+            <br>
+            <div mat-dialog-actions align="end">
+                <button mat-button (click)="closeDialog()" type="click">
+                <mat-icon>clear</mat-icon>
+                    Cancel
+                </button>
+                <button mat-raised-button color="primary" type="submit" (click)="create_or_update(confirmationMailForm.value)"
+                    [disabled]="!confirmationMailForm.valid">
+                    <mat-icon>{{'done'}}</mat-icon>
+                    {{'Submit'}}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/frontend/src/app/template-list/confirmation-detail.dialog.ts
+++ b/app/frontend/src/app/template-list/confirmation-detail.dialog.ts
@@ -1,0 +1,58 @@
+import { environment } from './../../environments/environment';
+import { Booking } from './../model-service/bookings/bookings';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialogRef, MatDialog } from '@angular/material/dialog';
+import { ConfirmationTemplatesService } from './../model-service/confirmationtemplates/confirmationtemplates.service';
+import { FormGroup, FormBuilder} from '@angular/forms';
+import { ConfirmationTemplate } from './../model-service/confirmationtemplates/confirmationtemplates';
+import { Component} from '@angular/core';
+
+@Component({
+  selector: 'app-confirmation-detail-dialog',
+  templateUrl: './confirmation-detail.dialog.html',
+})
+export class ConfirmationDetailDialog {
+  confirmationMailForm: FormGroup;
+  
+  isNew: boolean;
+  isEdit: boolean;
+  isSendingEmail: boolean;
+  booking: Booking = null;
+  template: ConfirmationTemplate;
+  templateParams: any;
+
+  apiKey = environment.apiKey;;
+
+  constructor(
+    public dialog: MatDialog,
+    private confirmationTemplatesService: ConfirmationTemplatesService,
+    public dialogRef: MatDialogRef<ConfirmationDetailDialog>,
+    private formBuilder: FormBuilder,
+    private snackbar: MatSnackBar
+  ) {
+    this.confirmationMailForm = this.formBuilder.group({
+      link_string: '',
+      subject: '',
+      template: ''
+    });
+    this.confirmationTemplatesService.getConfirmationTemplate()
+      .subscribe(
+        (template: ConfirmationTemplate) => {
+          delete template.id;
+          this.confirmationMailForm.setValue(template);
+        },
+        (err) => {
+        }
+      );
+  }
+
+  create_or_update(data: any) {
+    this.confirmationTemplatesService.updateTemplate(data).subscribe();
+    this.closeDialog();
+    this.snackbar.open('Updated confirmation template', 'OK', {duration: 5000, });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/app/frontend/src/app/template-list/template-list.component.html
+++ b/app/frontend/src/app/template-list/template-list.component.html
@@ -18,6 +18,22 @@
   <mat-paginator class="mat-elevation-z8" [pageSizeOptions]="[5, 10, 15]" showFirstLastButtons></mat-paginator>
   <div style="text-align: center; width: 100%; margin: 10px">
     <button mat-raised-button color="primary" (click)=openNew()>Add New Template</button>
-  <div>
+  </div>
+  <h1 style="padding-top:10px">Confirmation Templates List</h1>
+  <p>Click the row to edit.</p>
+  
+  <mat-table [dataSource]="confirmationTemplates" matSort class="mat-elevation-z8">
+    <ng-container matColumnDef="id">
+      <mat-header-cell *matHeaderCellDef [ngClass]="'w-40'" mat-sort-header>S/N</mat-header-cell>
+      <mat-cell *matCellDef="let confirmationTemplate" [ngClass]="'w-40'">{{confirmationTemplate.id}}</mat-cell>
+    </ng-container>
+    <ng-container matColumnDef="name">
+      <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
+      <mat-cell *matCellDef="let confirmationTemplate">{{confirmationTemplate.link_string}}</mat-cell>
+    </ng-container>
+    <mat-header-row *matHeaderRowDef="confirmationTableColumns"></mat-header-row>
+    <mat-row matRipple *matRowDef="let confirmationTemplate; columns: confirmationTableColumns;" (click)=openConfirmationDetail(confirmationTemplate)></mat-row>
+  </mat-table>
+  <mat-paginator class="mat-elevation-z8" [pageSizeOptions]="[5, 10, 15]" showFirstLastButtons></mat-paginator>
 </div>
 

--- a/app/frontend/src/app/template-list/template-list.component.ts
+++ b/app/frontend/src/app/template-list/template-list.component.ts
@@ -7,6 +7,10 @@ import { MatTableDataSource } from '@angular/material/table';
 import { EmailTemplate } from './../model-service/emailtemplates/emailtemplates';
 import { Component, OnInit, ViewChild } from '@angular/core';
 
+import { ConfirmationDetailDialog } from './confirmation-detail.dialog';
+import { ConfirmationTemplatesService } from './../model-service/confirmationtemplates/confirmationtemplates.service';
+import { ConfirmationTemplate } from './../model-service/confirmationtemplates/confirmationtemplates';
+
 @Component({
   selector: 'app-template-list',
   templateUrl: './template-list.component.html',
@@ -26,9 +30,13 @@ export class TemplateListComponent implements OnInit {
 
   isDialogOpen: boolean;
 
+  confirmationTemplates = new MatTableDataSource<ConfirmationTemplate>();
+  confirmationTableColumns: string[] = ['id', 'name'];
+
   constructor(
     public dialog: MatDialog,
-    private emailTemplatesService: EmailTemplatesService
+    private emailTemplatesService: EmailTemplatesService,
+    private confirmationTemplatesService: ConfirmationTemplatesService
   ) {
     this.isDialogOpen = false;
   }
@@ -40,6 +48,9 @@ export class TemplateListComponent implements OnInit {
     this.reloadData();
     this.templates.paginator = this.paginator;
     this.templates.sort = this.sort;
+    // Added here
+    this.confirmationTemplates.paginator = this.paginator;
+    this.confirmationTemplates.sort = this.sort;
   }
 
   openNew() {
@@ -96,6 +107,28 @@ export class TemplateListComponent implements OnInit {
       );
   }
 
+  openConfirmationDetail(row: { [x: string]: number; }) {
+    this.confirmationTemplatesService.getConfirmationTemplateById(row.id)
+      .subscribe(
+        (data: ConfirmationTemplate) => {
+          if (!this.isDialogOpen) {
+            this.isDialogOpen = true;
+            const dialogRef = this.dialog.open(ConfirmationDetailDialog,
+              { width: '800px',
+                data: {
+                  isEdit: true,
+                  confirmationTemplate: data
+                }
+              });
+            dialogRef.afterClosed().subscribe(() => {
+              this.reloadData();
+              this.isDialogOpen = false;
+            });
+          }
+        }
+      );
+  }
+
   reloadData() {
     this.emailTemplatesService.getTemplateList()
       .subscribe(
@@ -103,5 +136,11 @@ export class TemplateListComponent implements OnInit {
           this.templates.data = data;
         }
       );
+    this.confirmationTemplatesService.getConfirmationTemplateList()
+        .subscribe(
+          (data: ConfirmationTemplate[]) => {
+            this.confirmationTemplates.data = data;
+          }
+        )
   }
 }

--- a/app/frontend/src/app/toolbar/toolbar.component.html
+++ b/app/frontend/src/app/toolbar/toolbar.component.html
@@ -9,9 +9,7 @@
       <div class="services" *ngIf="lc.loginStatus.value; else elseBar">
         <a mat-button routerLink="/bookings" routerLinkActive="active">Booking List</a>
         <a mat-button routerLink="/items" routerLinkActive="active">Items</a>
-        <a mat-button routerLink="/templates" routerLinkActive="active">Email templates</a>
-        <a mat-button routerLink="/mailer" routerLinkActive="active">Send email</a>
-        <a mat-button routerLink="/confirmation_template" routerLinkActive="active">Confirmation template</a>
+        <a mat-button routerLink="/templates" routerLinkActive="active">Templates</a>
         <a mat-button routerLink="/edit" routerLinkActive="active">Make a Booking</a>
       </div>
 


### PR DESCRIPTION
1. Merged email template and confirmation plate under the same page
2. Remove 'send email' tab from the navigation bar